### PR TITLE
Make rm in build.sh conditional if the file exists

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #Clear out old generated files
-rm src/protos/master.rs
+if [ -z "src/protos/master.rs" ]; then
+  rm src/protos/master.rs
+fi
 
 # Builds the game from a text file into the needed binary format.
 cat games/game_design.pbtxt | protoc --encode=Maeve.Game protos/*.proto > games/game_design.pb


### PR DESCRIPTION
Previously the rm command ran every time, giving an error on the first run.

Now the behavior is to check to see if the file exists first, removing that error.