### PR TITLE
Make build.sh modular; accept custom proto names

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,14 @@
+# either use 'game_design' as the default or
+# a user supplied name
+filename=${1:-"game_design"}
+
 #Clear out old generated files
 if [ -z "src/protos/master.rs" ]; then
   rm src/protos/master.rs
 fi
 
 # Builds the game from a text file into the needed binary format.
-cat games/game_design.pbtxt | protoc --encode=Maeve.Game protos/*.proto > games/game_design.pb
+cat games/$filename.pbtxt | protoc --encode=Maeve.Game protos/*.proto > games/$filename.pb
 
 # Generate new files
 protoc --rust_out src/protos protos/*.proto


### PR DESCRIPTION
Previously `build.sh` was coupled to `game_design`.pbtext.

New behavior: Pass in one argument to specify any name the user likes. **Default behavior** is to still use `game_design`, so simply running `build.sh` is the exact same. 

Running `build.sh my-game` will look for a `my-game`.pbtext accordingly, if one creates a different named file.